### PR TITLE
Links to other quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nexmo APIs Quickstart Examples for PHP
 
+Quickstarts also available for: [Java](https://github.com/nexmo-community/nexmo-java-quickstart), [.NET](https://github.com/nexmo-community/nexmo-dotnet-quickstart), [Node.js](https://github.com/nexmo-community/nexmo-node-quickstart), [Python](https://github.com/nexmo-community/nexmo-python-quickstart), [Ruby](https://github.com/nexmo-community/nexmo-ruby-quickstart)
+
 The purpose of the quickstart guide is to provide simple examples focused on one goal. For example, sending an SMS, handling an incoming SMS webhook or making a Text to Speech call.
 
 ## Configure with Your Nexmo API Keys


### PR DESCRIPTION
While searching for something related to Nexmo (actually to test with Python), I came across this repo in Google search results. For the benefit of users, we should probably cross-link them so that if they, say, find the PHP repo and go "wait, I want the same thing but for Java", they can quickly move between them. I'll be submitting patches for all the other quickstarts.