### PR TITLE
Adding the unicode SMS sending example code

### DIFF
--- a/sms/send-unicode-sms.php
+++ b/sms/send-unicode-sms.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$basic  = new \Nexmo\Client\Credentials\Basic(NEXMO_API_KEY, NEXMO_API_SECRET);
+$client = new \Nexmo\Client($basic);
+
+$message = $client->message()->send([
+    'to' => TO_NUMBER,
+    'from' => 'Acme Inc',
+    'text' => 'こんにちは世界',
+    'type' => 'unicode'
+]);
+
+var_dump($message->getResponseData());


### PR DESCRIPTION
As per https://github.com/Nexmo/building-block-specs/blob/master/sms/specs/send-sms-unicode-SPEC.md