### PR TITLE
Bring placeholders inline with building block content

### DIFF
--- a/voice/earmuff-a-call/index.php
+++ b/voice/earmuff-a-call/index.php
@@ -5,6 +5,6 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$client->calls[NEXMO_CALL_UUID]->put(new \Nexmo\Call\Earmuff());
+$client->calls[UUID]->put(new \Nexmo\Call\Earmuff());
 sleep(3);
-$client->calls[NEXMO_CALL_UUID]->put(new \Nexmo\Call\Unearmuff());
+$client->calls[UUID]->put(new \Nexmo\Call\Unearmuff());

--- a/voice/mute-a-call/index.php
+++ b/voice/mute-a-call/index.php
@@ -5,6 +5,6 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$client->calls[NEXMO_CALL_UUID]->put(new \Nexmo\Call\Mute());
+$client->calls[UUID]->put(new \Nexmo\Call\Mute());
 sleep(3);
-$client->calls[NEXMO_CALL_UUID]->put(new \Nexmo\Call\Unmute());
+$client->calls[UUID]->put(new \Nexmo\Call\Unmute());

--- a/voice/play-audio-stream-in-to-call/index.php
+++ b/voice/play-audio-stream-in-to-call/index.php
@@ -5,6 +5,6 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$stream = $client->calls[NEXMO_CALL_UUID]->stream();
+$stream = $client->calls[UUID]->stream();
 $stream->setUrl('https://nexmo-community.github.io/ncco-examples/assets/voice_api_audio_streaming.mp3');
 $stream->put();

--- a/voice/play-dtmf-in-to-call/index.php
+++ b/voice/play-dtmf-in-to-call/index.php
@@ -5,6 +5,6 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$dtmf = $client->calls[NEXMO_CALL_UUID]->dtmf();
+$dtmf = $client->calls[UUID]->dtmf();
 $dtmf->setDigits('2468#');
 $dtmf->put();

--- a/voice/play-tts-in-to-call/index.php
+++ b/voice/play-tts-in-to-call/index.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$talk = $client->calls[NEXMO_CALL_UUID]->talk();
+$talk = $client->calls[UUID]->talk();
 $talk->setText(TEXT);
 $talk->setVoiceName('Kimberly');
 $talk->put();

--- a/voice/transfer-a-call/index.php
+++ b/voice/transfer-a-call/index.php
@@ -5,4 +5,4 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 $keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(NEXMO_APPLICATION_PRIVATE_KEY_PATH), NEXMO_APPLICATION_ID);
 $client = new \Nexmo\Client($keypair);
 
-$client->calls[NEXMO_CALL_UUID]->put(new \Nexmo\Call\Transfer("https://developer.nexmo.com/ncco/transfer.json"));
+$client->calls[UUID]->put(new \Nexmo\Call\Transfer("https://developer.nexmo.com/ncco/transfer.json"));


### PR DESCRIPTION
This change makes the PHP code hold the same placeholder variables as
are described in the building block examples, and match the building
block spec documents.

I spotted it here: https://developer.nexmo.com/voice/voice-api/building-blocks/earmuff-a-call/php which doesn't match https://github.com/Nexmo/building-block-specs/blob/master/voice/specs/earmuff-a-call-SPEC.md - then I fixed a few others the same while I was there.