### PR TITLE
Add examples for sending and receiving signed messages

### DIFF
--- a/sms/send-signed-sms.php
+++ b/sms/send-signed-sms.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// add a 3rd parameter to change the signature from md5hash to something else
+$signed = new Nexmo\Client\Credentials\SignatureSecret(NEXMO_API_KEY, NEXMO_API_SIGNATURE_SECRET);
+$client = new \Nexmo\Client($signed);
+
+$message = $client->message()->send([
+    'to' => TO_NUMBER,
+    'from' => FROM_NUMBER,
+    'text' => 'Super interesting message',
+]);
+
+$response = $message->getResponseData();
+echo "Message status: " . $response['messages'][0]['status'] . "\n";

--- a/sms/verify-signed-sms.php
+++ b/sms/verify-signed-sms.php
@@ -1,0 +1,20 @@
+<?php 
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$inbound = \Nexmo\Message\InboundMessage::createFromGlobals();
+
+if($inbound->isValid()){
+    $params = $inbound->getRequestData();
+    $signature = new Nexmo\Client\Signature($params, NEXMO_API_SIGNATURE_SECRET);
+    $validSig = $signature->check($params['sig']);
+
+    if($validSig) {
+        error_log("Valid signature");
+    } else {
+        error_log("Invalid signature");
+    }
+
+} else {
+    error_log('invalid message');
+}


### PR DESCRIPTION
Code examples for sending a signed message and receiving one and verifying its signature. Note that it uses the md5hash default so you will need to configure your account to that to test.